### PR TITLE
Add touch event support

### DIFF
--- a/htdocs/script.js
+++ b/htdocs/script.js
@@ -256,7 +256,7 @@
         previewFrame.style.backgroundImage = 'url(backgrounds/' + pageBackground + ')';
         canvasFrame.style.backgroundImage = 'url(backgrounds/' + pageBackground + ')';
 
-        canvas.element.onmousedown = function (e) {
+        canvas.element.onmousedown = canvas.element.ontouchstart = function (e) {
             // Only allow drawing if we have enough ink
             if (!inkMeter.subtractInk(1)) {
                 return;
@@ -287,7 +287,7 @@
             lastX = e.layerX;
             lastY = e.layerY;
         };
-        var onMove = canvas.element.onmousemove = function (e) {
+        var onMove = canvas.element.onmousemove = canvas.element.ontouchmove = function (e) {
             // We cache x and y to avoid bizzare browser bugs
             // Don't ask me why, but the second time you read e.layerX, it becomes zero!
             var x = e.layerX, y = e.layerY;
@@ -314,7 +314,7 @@
             lastX = x;
             lastY = y;
         };
-        canvas.element.onmouseup = function (e) {
+        canvas.element.onmouseup = canvas.element.ontouchend = function (e) {
             if (drawing) {
                 onMove(e);
 
@@ -1191,6 +1191,8 @@
             });
         };
     }
+
+    document.ontouchmove = function(e) { e.preventDefault(); }
 
     window.onerror = alert;
     window.onload = function () {


### PR DESCRIPTION
I realise this isn't your primary goal, This allows pictures to be drawn on devices that don't use mouse events, like an iPhone.

When I wanted to try this app out, I didn't have my 3DS to hand, so tried to draw some pictures on my iPhone. It didn't work. This PR fixes that!

I'd recommend testing on a New 3DS (which I don't have) because apparently they support both touch events and mouse events, and I don't know what would happen in that scenario. My hunch is it would be fine, though.